### PR TITLE
Introduce s-utf-delimiters, test public functions

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -7,6 +7,8 @@ t/00-load.t
 t/01-invalid.t
 t/02-constructs.t
 t/03-hooks.t
+t/04-extra.t
+t/05-functions.t
 t/changes.t
 t/completness.t
 t/manifest.t

--- a/lib/Syntax/Construct.pm
+++ b/lib/Syntax/Construct.pm
@@ -17,6 +17,7 @@ my %introduces = ( '5.024' => [qw[
                    '5.020' => [qw[
                                  attr-prototype drand48 %slice
                                  unicode6.3 \p{Unicode} utf8-locale
+                                 s-utf8-delimiters
                               ]],
                    '5.018' => [qw[
                                  computed-labels while-each
@@ -37,16 +38,23 @@ my %introduces = ( '5.024' => [qw[
                                  stack-file-test recursive-sort /p
                                  lexical-$_
                               ]],
+                   old => [qw[
+                                 s-utf8-delimiters-hack
+                          ]],
                  );
 
-my %removed = ( 'auto-deref' => '5.024',
-                'lexical-$_' => '5.024',
+my %removed = ( 'auto-deref'             => '5.024',
+                'lexical-$_'             => '5.024',
+                's-utf8-delimiters-hack' => '5.020',
               );
 
-my %introduced = map {
+my %_introduced = map {
     my $version = $_;
     map { $_ => $version } @{ $introduces{$version} }
 } keys %introduces;
+
+my %introduced = %_introduced;
+delete @introduced{ @{ $introduces{old} } };
 
 sub _hook {
     { drand48 => sub {
@@ -419,6 +427,12 @@ L<perl5200delta/Core Enhancements>.
 See B<use locale now works on UTF-8 locales> in
 L<perl5200delta/Core Enhancements>.
 
+=head3 s-utf8-delimiters
+
+See L<perl5200delta/Regular Expressions>: in older Perl versions, a
+hack around was possible: to specify the delimiter twice in
+substitution. Use C<s-utf8-delimiters-hack> if your code uses it.
+
 =head2 5.022
 
 =head3 <<>>
@@ -481,6 +495,9 @@ L<perldelta/New \b{lb} boundary in regular expressions>.
 
 L<perldelta/printf and sprintf now allow reordered precision arguments>.
 
+=for completeness
+=head2 old
+=head3 s-utf8-delimiters-hack
 
 =head1 AUTHOR
 

--- a/t/02-constructs.t
+++ b/t/02-constructs.t
@@ -22,7 +22,6 @@ my %tests = (
           'sprintf q(|%.*2$d|), 7, 3', '|007|' ],
     ],
 
-
     '5.022' => [
         [ '<<>>',
           'local @ARGV = $0; chomp(my $line = <<>>); $line',
@@ -54,7 +53,6 @@ my %tests = (
           . '"ab" =~ /a${s}b/x', 1 ]
     ],
 
-
     '5.020' => [
         [ 'attr-prototype',
           'sub func : prototype($$) {} prototype \&func', '$$' ],
@@ -68,9 +66,10 @@ my %tests = (
           'my $i; /\p{Age: 6.3}/ and $i++ for map chr, 0 .. 0xffff; $i', 5 ],
         [ '\p{Unicode}',
           'scalar grep $_ =~ /\p{Unicode}/, "a", "\N{U+0FFFFF}"', 2 ],
+        [ 's-utf8-delimiters',
+          "'a' =~ s\N{U+2759}a\N{U+2759}b\N{U+2759}r", 'b' ],
         # TODO: 'utf8-locale'.
     ],
-
 
     '5.018' => [
         [ 'computed-labels',
@@ -224,8 +223,10 @@ readline default
     '5.014' => [
         [ '/l',
         [ '/d',
-
     '5.020' => [
         [ 'utf8-locale',
+    old => [
+        [ 's-utf8-delimiters-hack', # See 04-extra.t
 
 =cut
+

--- a/t/04-extra.t
+++ b/t/04-extra.t
@@ -1,0 +1,16 @@
+#!/usr/bin/perl
+use warnings;
+use strict;
+
+use Test::More tests => 1;
+use Syntax::Construct ();
+
+SKIP: {
+    $] lt '5.020' or skip '5.018 or older needed', 1;
+
+    my $string = 'a';
+    eval "use utf8; \$string =~ s\N{U+2759}a\N{U+2759}\N{U+2759}b\N{U+2759}";
+    is($string, 'b', 's-utf8-delimiters-hack');
+}
+
+done_testing();

--- a/t/05-functions.t
+++ b/t/05-functions.t
@@ -1,0 +1,18 @@
+#!/usr/bin/perl
+use warnings;
+use strict;
+
+use Test::More tests => 5;
+
+use Syntax::Construct ();
+
+is(Syntax::Construct::introduced('//'), '5.010', 'introduced-arg');
+
+my @introduced = Syntax::Construct::introduced();
+is(@introduced, 59, 'introduced all');
+
+is(Syntax::Construct::removed('auto-deref'), '5.024', 'removed-arg');
+is(Syntax::Construct::removed(), 3, 'removed all');
+
+is( Syntax::Construct::introduced('s-utf8-delimiters-hack'),
+    undef, 'old not introduced');

--- a/t/completness.t
+++ b/t/completness.t
@@ -17,31 +17,35 @@ my $libfile = $INC{'Syntax/Construct.pm'};
 open my $IN, '<', $libfile or die $!;
 my $version;
 while (my $line = <$IN>) {
-    if (my ($v) = $line =~ /^=head2 ([.0-9]+)/) {
+    if (my ($v) = $line =~ /^=head2 ([.0-9]+|old)/) {
         $version = $v;
 
-    } elsif (my ($constrs) = $line =~ /^=head3 (.*)/) {
+    } elsif (my ($constrs) = $line =~ /^=head3 (.*)$/) {
         for my $constr (split ' ', $constrs) {
             $constructs{$constr}{pod}++;
             $constructs{$constr}{version}{$version}++;
         }
 
-    } elsif ($line =~ / '(5\.[0-9]{3})' => \[qw\[$/) {
-        my $v = $1;
+    } elsif ($line =~ / (?:'(5\.[0-9]{3})'|(old)) => \[qw\[$/) {
+        my $v = $1 || $2;
         until ((my $l = <$IN>) =~ /\]\],$/) {
             for my $constr ($l =~ /(\S+)/g) {
                 $constructs{$constr}{code}++;
                 $constructs{$constr}{version}{$v}++;
             }
         }
+    } elsif (my ($removed_construct, $rm_version)
+             = $line =~ / '([^']*)' +=> '(5\.[0-9]{3})',$/
+    ) {
+        $constructs{$removed_construct}{removed}{$rm_version}++;
     }
 }
 
 open my $TEST, '<', "$FindBin::Bin/02-constructs.t" or die $!;
 undef $version;
 while (<$TEST>) {
-    if (my ($v) = /^ +'([.0-9]+)' => \[$/) {
-        $version = $v;
+    if (/^ +(?:'([.0-9]+)'|(old)) => \[$/) {
+        $version = $1 || $2;
     }
     if (my ($constr) = /^ +\[ '(.+)',/) {
         $constructs{$constr}{test}++;
@@ -49,12 +53,19 @@ while (<$TEST>) {
     }
 }
 
+my $count_old = 0;
 for my $constr (keys %constructs) {
     is($constructs{$constr}{$_}, 1, "$_ for $constr") for qw( pod code test );
 
     my @versions = keys %{ $constructs{$constr}{version} };
     is(@versions, 1, "versions $constr");
     is($constructs{$constr}{version}{ $versions[0] }, 3, "version $constr");
+
+    if ('old' eq $versions[0]) {
+        ++$count_old;
+        is(keys %{ $constructs{$constr}{removed} }, 1, "$constr removed once");
+    }
+
 }
 
-done_testing(5 * keys %constructs);
+done_testing($count_old + 5 * keys %constructs);


### PR DESCRIPTION
together with s-utf-delimiters-hack for older version. To make it work,
a fake internal version "old" was introduced.

Fixes #13.