### PR TITLE
Reset the original locale after testing the Turkic locale

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Syntax-Construct
 
+1.037   2024-06-20
+        - Fix turkic casing: reset original locale
+
 1.036   2024-06-12
         - Fix treating some stable versions as unstable
 

--- a/lib/Syntax/Construct.pm
+++ b/lib/Syntax/Construct.pm
@@ -4,7 +4,7 @@ use 5.006002;
 use strict;
 use warnings;
 
-our $VERSION = '1.036';
+our $VERSION = '1.037';
 
 my %introduces = do { no warnings 'qw';
                  ( '5.040' => [qw[
@@ -201,8 +201,12 @@ sub _hook {
           eval {
               use locale;
               require POSIX;
-              POSIX::setlocale(POSIX::LC_ALL(), 'tr_TR.UTF-8');
-              lc 'I' ne 'i'
+              my $orig_locale = POSIX::setlocale(POSIX::LC_CTYPE());
+              (POSIX::setlocale(POSIX::LC_CTYPE(), 'tr_TR.UTF-8') || "")
+                  eq 'tr_TR.UTF-8' or die;
+              my $cmp = lc 'I' ne 'i';
+              POSIX::setlocale(POSIX::LC_CTYPE(), $orig_locale);
+              $cmp
           } or die 'Turkic locale casing not working at '
               . _position(1) . "\.\n";
       },
@@ -297,7 +301,7 @@ Syntax::Construct - Explicitly state which non-feature constructs are used in th
 
 =head1 VERSION
 
-Version 1.036
+Version 1.037
 
 =head1 SYNOPSIS
 

--- a/t/02-constructs.t
+++ b/t/02-constructs.t
@@ -115,8 +115,13 @@ my %tests = (
           q("\N{ORIYA DIGIT FOUR}" =~ m'\N{ORIYA DIGIT FOUR}'), 1 ],
         [ 'turkic-casing',
           'use locale; use POSIX "locale_h";' . skippable(
-              'eval{setlocale(LC_ALL, "tr_TR.UTF-8") eq "tr_TR.UTF-8" or die;'
-                  . ' lc "I" eq "\N{LATIN SMALL LETTER DOTLESS I}"}',
+              'my $o = setlocale(LC_CTYPE);'
+              . 'eval {'
+              .    '(setlocale(LC_CTYPE, "tr_TR.UTF-8") || "") eq "tr_TR.UTF-8"'
+              .        'or die;'
+              .    'my $r = lc "I" eq "\N{LATIN SMALL LETTER DOTLESS I}";'
+              .    'setlocale(LC_CTYPE, $o);'
+              . '$r }',
               '": testing locale not supported"',
               "", '1'),
           1 ],


### PR DESCRIPTION
Problem found by Haarg, thank you! [PerlMonks](https://www.perlmonks.org/?node_id=11160128):

> this is broken in perl 5.37.4 through 5.39.2. It was broken with [818cdb7aa9f85227c1c7313257c6204c872beb94](/Perl/perl5/commit/818cdb7aa9f85227c1c7313257c6204c872beb94) and fixed with [5ba25c116c8573b68a6103113d3b831e46f55bee](/Perl/perl5/commit/5ba25c116c8573b68a6103113d3b831e46f55bee).



Fixes #58 